### PR TITLE
fixed the help message in ./help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Interesting features:
 • Rooms! Run /room to see all rooms and use /room #foo to join a new room.
 • Markdown support! Tables, headers, italics and everything. Just use \n in place of newlines.
 • Code syntax highlighting. Use Markdown fences to send code. Run /example-code to see an example.
-• Direct messages! Send a DM using =user <msg>.
+• Direct messages! Send a quick DM using =user <msg> or stay in DMs by running ./room @user.
 • Timezone support, use /tz Continent/City to set your timezone.
 • Built in Tic Tac Toe and Hangman! Run /tic or /hang <word> to start new games.
 • Emoji replacements! :rocket: => 🚀  (like on Slack and Discord)

--- a/commands.go
+++ b/commands.go
@@ -393,7 +393,7 @@ Interesting features:
 * Rooms! Run ./room to see all rooms and use ./room #foo to join a new room.
 * Markdown support! Tables, headers, italics and everything. Just use \\n in place of newlines.
 * Code syntax highlighting. Use Markdown fences to send code. Run ./example-code to see an example.
-* Direct messages! Send a quick DM using ./@user <msg> or stay in DMs by running ./room @user.
+* Direct messages! Send a quick DM using =user <msg> or stay in DMs by running ./room @user.
 * Timezone support, use ./tz Continent/City to set your timezone.
 * Built in Tic Tac Toe and Hangman! Run ./tic or ./hang <word> to start new games.
 * Emoji replacements! \:rocket\: => :rocket: (like on Slack and Discord)


### PR DESCRIPTION
I synced the message output when using ./help and also the text in README.md to read the same line for direct messaging. At `devzat.hackclub.com` it still reads the wrong output for dm when you use `./help`:

```
c1sc0: ./help
Welcome to Devzat! Devzat is chat over SSH: github.com/quackduck/devzat
Because there's SSH apps on all platforms, even on mobile, you can join from anywhere.

Interesting features:
• Many, many commands. Run ./commands.
• Rooms! Run ./room to see all rooms and use ./room #foo to join a new room.
• Markdown support! Tables, headers, italics and everything. Just use \n in place of newlines.
• Code syntax highlighting. Use Markdown fences to send code. Run ./example-code to see an example.
• Direct messages! Send a quick DM using ./@user <msg> or stay in DMs by running ./room @user. <------ HERE!!!
• Timezone support, use ./tz Continent/City to set your timezone.
• Built in Tic Tac Toe and Hangman! Run ./tic or ./hang <word> to start new games.
• Emoji replacements! :rocket: => 🚀  (like on Slack and Discord)

For replacing newlines, I often use bulkseotools.com/add-remove-line-breaks.php.

Made by Ishan Goel with feature ideas from friends.
Thanks to Caleb Denio for lending his server!
```

Also I removed a file called "l" which I suppose was added by accident.