### PR TITLE
added https:// to twitter url, makes it aktually openable from terminal

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -57,7 +57,7 @@ func sendCurrentUsersTwitterMessage() {
 			mainRoom.broadcast(devbot, "err: "+err.Error(), true)
 			return
 		}
-		mainRoom.broadcast(devbot, "https://twitter.com/"+t.User.ScreenName+"/status/"+t.IDStr, true)
+		mainRoom.broadcast(devbot, "https\://twitter.com/"+t.User.ScreenName+"/status/"+t.IDStr, true)
 	}()
 	//broadcast(devbot, tweet.Entities.Urls)
 }

--- a/twitter.go
+++ b/twitter.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"time"
+
 	"github.com/acarl005/stripansi"
 	"github.com/dghubble/go-twitter/twitter"
 	"github.com/dghubble/oauth1"
-	"io/ioutil"
-	"time"
 )
 
 var (
@@ -56,7 +57,7 @@ func sendCurrentUsersTwitterMessage() {
 			mainRoom.broadcast(devbot, "err: "+err.Error(), true)
 			return
 		}
-		mainRoom.broadcast(devbot, "twitter.com/"+t.User.ScreenName+"/status/"+t.IDStr, true)
+		mainRoom.broadcast(devbot, "https://twitter.com/"+t.User.ScreenName+"/status/"+t.IDStr, true)
 	}()
 	//broadcast(devbot, tweet.Entities.Urls)
 }


### PR DESCRIPTION
So this way it makes the link openable from terminal. Let's say you are using `gnome-terminal` like I do on linux, and you right click that link you will get a `open in browser`. This way you can actually directly open that link without needing to copy paste it.