### PR TITLE
Generate the user ID based on their public key instead of IP

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -339,8 +339,7 @@ func idCMD(line string, u *user, _ bool) {
 		u.room.broadcast("", "User not found")
 		return
 	}
-	u.room.broadcast("IP based id", victim.uid)
-	u.room.broadcast("Pubkey based id", victim.cid)
+	u.room.broadcast("", victim.id)
 }
 
 func nickCMD(line string, u *user, _ bool) {

--- a/commands.go
+++ b/commands.go
@@ -38,7 +38,7 @@ var (
 		{"rest", commandsRestCMD, "", "Uncommon commands list"}}
 	cmdsRest = []cmd{
 		{"people", peopleCMD, "", "See info about nice people who joined"},
-		{"id", idCMD, "<user>", "Get a unique ID for a user (hashed IP)"},
+		{"id", idCMD, "<user>", "Get a unique ID for a user (hashed IP | SSH Public key)"},
 		{"eg-code", exampleCodeCMD, "", "Example syntax-highlighted code"},
 		{"banIP", banIPCMD, "<IP>", "Ban an IP (admin)"},
 		{"ban", banCMD, "<user>", "Ban <user> (admin)"},
@@ -339,7 +339,8 @@ func idCMD(line string, u *user, _ bool) {
 		u.room.broadcast("", "User not found")
 		return
 	}
-	u.room.broadcast("", victim.id)
+	u.room.broadcast("IP based id", victim.uid)
+	u.room.broadcast("Pubkey based id", victim.cid)
 }
 
 func nickCMD(line string, u *user, _ bool) {

--- a/commands.go
+++ b/commands.go
@@ -38,7 +38,7 @@ var (
 		{"rest", commandsRestCMD, "", "Uncommon commands list"}}
 	cmdsRest = []cmd{
 		{"people", peopleCMD, "", "See info about nice people who joined"},
-		{"id", idCMD, "<user>", "Get a unique ID for a user (hashed IP | SSH Public key)"},
+		{"id", idCMD, "<user>", "Get a unique ID for a user (hashed key)"},
 		{"eg-code", exampleCodeCMD, "", "Example syntax-highlighted code"},
 		{"banIP", banIPCMD, "<IP>", "Ban an IP (admin)"},
 		{"ban", banCMD, "<user>", "Ban <user> (admin)"},

--- a/devchat.go
+++ b/devchat.go
@@ -186,7 +186,6 @@ func newUser(s ssh.Session) *user {
 	hash := sha256.New()
 	pubkey := s.PublicKey()
 	if pubkey != nil {
-		fmt.Printf("key: %s\n", pubkey.Marshal())
 		hash.Write([]byte(pubkey.Marshal()))
 	} else { // If we can't get the public key fall back to the IP.
 		hash.Write([]byte(host))

--- a/devchat.go
+++ b/devchat.go
@@ -58,7 +58,8 @@ type user struct {
 	bell          bool
 	pingEverytime bool
 	color         string
-	id            string
+	uid           string
+	cid           string
 	addr          string
 	win           ssh.Window
 	closeOnce     sync.Once
@@ -187,12 +188,13 @@ func newUser(s ssh.Session) *user {
 	pty, winChan, _ := s.Pty()
 	w := pty.Window
 	host, _, _ := net.SplitHostPort(s.RemoteAddr().String()) // definitely should not give an err
-	hash := sha256.New()
+	ip_hash := sha256.New()
+	config_hash := sha256.New()
 	pubkey := s.PublicKey()
 	if pubkey != nil {
-		hash.Write([]byte(pubkey.Marshal()))
+		config_hash.Write([]byte(pubkey.Marshal()))
 	} else { // If we can't get the public key fall back to the IP.
-		hash.Write([]byte(host))
+		ip_hash.Write([]byte(host))
 	}
 
 	u := &user{
@@ -200,7 +202,8 @@ func newUser(s ssh.Session) *user {
 		session:       s,
 		term:          term,
 		bell:          true,
-		id:            hex.EncodeToString(hash.Sum(nil)),
+		uid:           hex.EncodeToString(ip_hash.Sum(nil)),     // User ID = IP
+		cid:           hex.EncodeToString(config_hash.Sum(nil)), // Config ID = Pubkey
 		addr:          host,
 		win:           w,
 		lastTimestamp: time.Now(),
@@ -214,25 +217,25 @@ func newUser(s ssh.Session) *user {
 		}
 	}()
 
-	l.Println("Connected " + u.name + " [" + u.id + "]")
+	l.Println("Connected " + u.name + " [" + u.uid + "]")
 
 	for i := range bans {
-		if u.addr == bans[i] || u.id == bans[i] { // allow banning by ID
-			if u.id == bans[i] { // then replace the ID in the ban with the actual IP
+		if u.addr == bans[i] || u.uid == bans[i] { // allow banning by ID
+			if u.uid == bans[i] { // then replace the ID in the ban with the actual IP
 				bans[i] = u.addr
 				saveBans()
 			}
 			l.Println("Rejected " + u.name + " [" + u.addr + "]")
-			u.writeln(devbot, "**You are banned**. If you feel this was done wrongly, please reach out at github.com/quackduck/devzat/issues. Please include the following information: [ID "+u.id+"]")
+			u.writeln(devbot, "**You are banned**. If you feel this was done wrongly, please reach out at github.com/quackduck/devzat/issues. Please include the following information: [ID "+u.uid+"]")
 			u.close("")
 			return nil
 		}
 	}
-	idsInMinToTimes[u.id]++
+	idsInMinToTimes[u.uid]++
 	time.AfterFunc(60*time.Second, func() {
-		idsInMinToTimes[u.id]--
+		idsInMinToTimes[u.uid]--
 	})
-	if idsInMinToTimes[u.id] > 6 {
+	if idsInMinToTimes[u.uid] > 6 {
 		bans = append(bans, u.addr)
 		mainRoom.broadcast(devbot, u.name+" has been banned automatically. IP: "+u.addr)
 		return nil
@@ -386,11 +389,11 @@ func (u *user) repl() {
 		}
 		u.term.Write([]byte(strings.Repeat("\033[A\033[2K", int(math.Ceil(float64(lenString(u.name+line)+2)/(float64(u.win.Width))))))) // basically, ceil(length of line divided by term width)
 
-		antispamMessages[u.id]++
+		antispamMessages[u.uid]++
 		time.AfterFunc(5*time.Second, func() {
-			antispamMessages[u.id]--
+			antispamMessages[u.uid]--
 		})
-		if antispamMessages[u.id] >= 50 {
+		if antispamMessages[u.uid] >= 50 {
 			if !stringsContain(bans, u.addr) {
 				bans = append(bans, u.addr)
 				saveBans()

--- a/devchat.go
+++ b/devchat.go
@@ -184,7 +184,13 @@ func newUser(s ssh.Session) *user {
 	w := pty.Window
 	host, _, _ := net.SplitHostPort(s.RemoteAddr().String()) // definitely should not give an err
 	hash := sha256.New()
-	hash.Write([]byte(host))
+	pubkey := s.PublicKey()
+	if pubkey != nil {
+		fmt.Printf("key: %s\n", pubkey.Marshal())
+		hash.Write([]byte(pubkey.Marshal()))
+	} else { // If we can't get the public key fall back to the IP.
+		hash.Write([]byte(host))
+	}
 
 	u := &user{
 		name:          s.User(),

--- a/devchat.go
+++ b/devchat.go
@@ -112,6 +112,10 @@ func main() {
 		}()
 		u.repl()
 	})
+	publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
+	})
+
 	var err error
 	if os.Getenv("PORT") != "" {
 		port, err = strconv.Atoi(os.Getenv("PORT"))
@@ -131,7 +135,7 @@ func main() {
 			}
 		}
 	}()
-	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"))
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), publicKeyOption)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/devchat.go
+++ b/devchat.go
@@ -112,10 +112,6 @@ func main() {
 		}()
 		u.repl()
 	})
-	publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
-		return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
-	})
-
 	var err error
 	if os.Getenv("PORT") != "" {
 		port, err = strconv.Atoi(os.Getenv("PORT"))
@@ -135,7 +131,9 @@ func main() {
 			}
 		}
 	}()
-	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), publicKeyOption)
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), func(ctx ssh.Context, key ssh.PublicKey) bool {
+		return true // allow all keys, this lets us hash pubkeys later
+	})
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -336,7 +334,6 @@ func (u *user) pickUsername(possibleName string) (ok bool) {
 	var err error
 	for {
 		if possibleName == "" {
-			u.writeln("", "No username chosen. Pick one:")
 		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
 			u.writeln("", "Your username is invalid. Pick a different one:")
 		} else if userDuplicate(u.room, possibleName) {

--- a/devchat.go
+++ b/devchat.go
@@ -336,8 +336,18 @@ func (u *user) rWriteln(msg string) {
 func (u *user) pickUsername(possibleName string) (ok bool) {
 	possibleName = cleanName(possibleName)
 	var err error
-	for possibleName == "" || possibleName == "devbot" || strings.HasPrefix(possibleName, "#") || userDuplicate(u.room, possibleName) {
-		u.writeln("", "Your username is already in use. Pick a different one:")
+	for {
+		if possibleName == "" {
+			u.writeln("", "No username chosen. Pick one:")
+		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
+			u.writeln("", "Your username is invalid. Pick a different one:")
+		} else if userDuplicate(u.room, possibleName) {
+			u.writeln("", "Your username is already in use. Pick a different one:")
+		} else {
+			possibleName = cleanName(possibleName)
+			break
+		}
+
 		u.term.SetPrompt("> ")
 		possibleName, err = u.term.ReadLine()
 		if err != nil {
@@ -346,6 +356,7 @@ func (u *user) pickUsername(possibleName string) (ok bool) {
 		}
 		possibleName = cleanName(possibleName)
 	}
+
 	u.name = possibleName
 	idx := rand.Intn(len(styles) * 140 / 100) // 40% chance of a random color
 	if idx >= len(styles) {                   // allow the possibility of having a completely random RGB color

--- a/devchat.go
+++ b/devchat.go
@@ -336,18 +336,8 @@ func (u *user) rWriteln(msg string) {
 func (u *user) pickUsername(possibleName string) (ok bool) {
 	possibleName = cleanName(possibleName)
 	var err error
-	for {
-		if possibleName == "" {
-			u.writeln("", "No username chosen. Pick one:")
-		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
-			u.writeln("", "Your username is invalid. Pick a different one:")
-		} else if userDuplicate(u.room, possibleName) {
-			u.writeln("", "Your username is already in use. Pick a different one:")
-		} else {
-			possibleName = cleanName(possibleName)
-			break
-		}
-
+	for possibleName == "" || possibleName == "devbot" || strings.HasPrefix(possibleName, "#") || userDuplicate(u.room, possibleName) {
+		u.writeln("", "Your username is already in use. Pick a different one:")
 		u.term.SetPrompt("> ")
 		possibleName, err = u.term.ReadLine()
 		if err != nil {
@@ -356,7 +346,6 @@ func (u *user) pickUsername(possibleName string) (ok bool) {
 		}
 		possibleName = cleanName(possibleName)
 	}
-
 	u.name = possibleName
 	idx := rand.Intn(len(styles) * 140 / 100) // 40% chance of a random color
 	if idx >= len(styles) {                   // allow the possibility of having a completely random RGB color

--- a/util.go
+++ b/util.go
@@ -20,7 +20,7 @@ var (
 	art    = getASCIIArt()
 	admins = []string{"d84447e08901391eb36aa8e6d9372b548af55bee3799cd3abb6cdd503fdf2d82", // Ishan Goel
 		"f5c7f9826b6e143f6e9c3920767680f503f259570f121138b2465bb2b052a85d", // Ella Xu - hackclub
-		"6056734cc4d9fce31569167735e4808382004629a2d7fe6cb486e663714452fc", // Tommy Pujol - hackclub
+		"ac416b02c106e7407e8e53e74b40d96d6f7c11e365c285a8ab825c219f443dcd", // Tommy Pujol - hackclub
 		"e9d47bb4522345d019086d0ed48da8ce491a491923a44c59fd6bfffe6ea73317", // Arav Narula - twitter
 		"1eab2de20e41abed903ab2f22e7ff56dc059666dbe2ebbce07a8afeece8d0424", // Shok - school
 		"12a9f108e7420460864de3d46610f722e69c80b2ac2fb1e2ada34aa952bbd73e", // jmw: github.com/ciearius
@@ -67,7 +67,7 @@ func autogenCommands(cmds []cmd) string {
 // check if a user is an admin
 func auth(u *user) bool {
 	for _, id := range admins {
-		if u.uid == id || u.addr == id {
+		if u.id == id || u.addr == id {
 			return true
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -67,7 +67,7 @@ func autogenCommands(cmds []cmd) string {
 // check if a user is an admin
 func auth(u *user) bool {
 	for _, id := range admins {
-		if u.id == id || u.addr == id {
+		if u.uid == id || u.addr == id {
 			return true
 		}
 	}


### PR DESCRIPTION
Since IP's can change, it's better if we get the ID from the public key. This has a few benefits, such as:

* People in the same network/household will be able to connect to the chat even if one person is banned.
* Admin takeover is much harder since instead of needing to be in the same network, you will need their public/private key pair.
* A person can connect from anywhere and as long as they have their key they can prove their legitimacy. (i.e. a random person called "ishan" on the chat won't be able to act the real ishan since your ID will be static and thus the fake ishan will be detected).

In the case that a user logged in without using their key pair, we will still get their ID from the IP, but we still gain all the benefits of pubkey authentication. 