### PR TITLE
Make public key auth into an option.

### DIFF
--- a/devchat.go
+++ b/devchat.go
@@ -131,9 +131,12 @@ func main() {
 			}
 		}
 	}()
-	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), func(ctx ssh.Context, key ssh.PublicKey) bool {
-		return true // allow all keys, this lets us hash pubkeys later
+
+	publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
 	})
+
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), publicKeyOption)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -327,7 +330,6 @@ func (u *user) rWriteln(msg string) {
 		u.term.Write([]byte(msg + "\n"))
 	}
 }
-
 
 func (u *user) pickUsername(possibleName string) (ok bool) {
 	possibleName = cleanName(possibleName)


### PR DESCRIPTION
In this [commit](https://github.com/quackduck/devzat/pull/55/commits/afabb2073b8db09c10a0918aaee49957eb19fb1b) you changed the ListenAndServe options from this:

```go
publicKeyOption := ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
	return true // allow all keys, or use ssh.KeysEqual() to compare against known keys
})
err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), publicKeyOption)
```

to this:

```go
err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), func(ctx ssh.Context, key ssh.PublicKey) bool {
	return true // allow all keys, this lets us hash pubkeys later
})
```

However, there is a mistake in here because in the ListenAndServe declaration it's expecting an Option (https://github.com/gliderlabs/ssh/blob/4204f8c42d3d753b4c6bbed20ea3b116f1e2ffbc/ssh.go#L101)

```go
func ListenAndServe(addr string, handler Handler, options ...Option) error
```

The option to allow all keys to connect is obtained with the PublicKeyAuth option defined [here](https://github.com/gliderlabs/ssh/blob/30ec06db4e743ac9f827a69c8b8cfb84064a6dc7/options.go#L18). In the current code because you are passing a function and not an option, the option is not set and thus when the code gets to:

```go
pubkey := s.PublicKey()
if pubkey != nil {
	hash.Write([]byte(pubkey.Marshal()))
} else { // If we can't get the public key fall back to the IP.
	hash.Write([]byte(host))
}
```

It will always fall back to the IP because since the public key authentication is disabled, it will not be able to obtain the key.