### PR TITLE
Fixed login without ssh key.

### DIFF
--- a/devchat.go
+++ b/devchat.go
@@ -131,9 +131,10 @@ func main() {
 			}
 		}
 	}()
-	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
-		return true // allow all keys, this lets us hash pubkeys later
-	}))
+	//err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"), ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
+		//return true // allow all keys, this lets us hash pubkeys later
+	//}))
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", port), nil, ssh.HostKeyFile(os.Getenv("HOME")+"/.ssh/id_rsa"))
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
This is a very lazy fix but it allow
people to login without copying ssh
keys. The ssh key functionality should
be put back in after more test to
understand how it works.