### PR TITLE
Fixed finding user's pronouns.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -540,7 +540,7 @@ func shrugCMD(line string, u *user) {
 }
 
 func pronounsCMD(line string, u *user) {
-	args := strings.Fields(strings.ReplaceAll(strings.ToLower(line), "\n", ""))
+	args := strings.Fields(line)
 
 	if len(args) == 1 && strings.HasPrefix(args[0], "@") {
 		victim, ok := findUserByName(u.room, args[0][1:])
@@ -552,7 +552,7 @@ func pronounsCMD(line string, u *user) {
 		return
 	}
 
-	u.pronouns = args
+	u.pronouns = strings.Fields(strings.ReplaceAll(strings.ToLower(line), "\n", ""))
 	//u.changeColor(u.color) // refresh pronouns
 	u.room.broadcast(devbot, u.name+" now goes by "+u.displayPronouns())
 }


### PR DESCRIPTION
If there was a capitalized letter in the
username, the command failed to find them.