### PR TITLE
Admin flair

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -483,9 +483,11 @@ func colorCMD(rest string, u *user) {
 }
 
 func adminsCMD(_ string, u *user) {
+	msg := "Admins:  \n"
 	for i := range admins {
-		u.room.broadcast(admins[i], adminsInfo[i])
+		msg += admins[i] + ": " + i + "  \n"
 	}
+	u.room.broadcast(devbot, msg)
 }
 
 func peopleCMD(_ string, u *user) {

--- a/commands.go
+++ b/commands.go
@@ -51,6 +51,7 @@ var (
 	cmdsRest = []cmd{
 		{"people", peopleCMD, "", "See info about nice people who joined"},
 		{"id", idCMD, "<user>", "Get a unique ID for a user (hashed key)"},
+		{"admins", adminsCMD, "", "Print the ID (hashed key) for all admins"},
 		{"eg-code", exampleCodeCMD, "[big]", "Example syntax-highlighted code"},
 		{"lsbans", listBansCMD, "", "List banned IDs"},
 		{"ban", banCMD, "<user>", "Ban <user> (admin)"},
@@ -478,6 +479,12 @@ func colorCMD(rest string, u *user) {
 		u.room.broadcast(devbot, "you're using "+u.color)
 	} else if err := u.changeColor(rest); err != nil {
 		u.room.broadcast(devbot, err.Error())
+	}
+}
+
+func adminsCMD(_ string, u *user) {
+	for i, _ := range admins {
+		u.room.broadcast(admins[i], adminsInfo[i])
 	}
 }
 

--- a/commands.go
+++ b/commands.go
@@ -483,7 +483,7 @@ func colorCMD(rest string, u *user) {
 }
 
 func adminsCMD(_ string, u *user) {
-	for i, _ := range admins {
+	for i := range admins {
 		u.room.broadcast(admins[i], adminsInfo[i])
 	}
 }

--- a/util.go
+++ b/util.go
@@ -21,26 +21,29 @@ import (
 )
 
 var (
-	art    = getASCIIArt()
-	admins = getAdmins()
+	art                = getASCIIArt()
+	admins, adminsInfo = getAdmins()
 )
 
-func getAdmins() []string {
+func getAdmins() ([]string, []string) {
 	data, err := ioutil.ReadFile("admins.json")
 	if err != nil {
 		fmt.Println("Error reading admins.json:", err, ". Make an admins.json file to add admins.")
-		return []string{}
+		return []string{}, []string{}
 	}
 	var adminsList map[string]string // id to info
 	err = json.Unmarshal(data, &adminsList)
 	if err != nil {
-		return []string{}
+		fmt.Println("Error in formating.")
+		return []string{}, []string{}
 	}
 	ids := make([]string, 0, len(adminsList))
-	for id := range adminsList {
+	infos := make([]string, 0, len(adminsList))
+	for id, info := range adminsList {
 		ids = append(ids, id)
+		infos = append(infos, info)
 	}
-	return ids
+	return ids, infos
 }
 
 func getASCIIArt() string {

--- a/util.go
+++ b/util.go
@@ -60,6 +60,9 @@ func printUsersInRoom(r *room) string {
 		return names
 	}
 	for _, us := range r.users {
+		if auth(us) {
+			names += "⭐"
+		}
 		names += us.name + " "
 	}
 	names = names[:len(names)-1] // cut extra space at the end

--- a/util.go
+++ b/util.go
@@ -51,9 +51,6 @@ func getASCIIArt() string {
 func printUsersInRoom(r *room) string {
 	names := ""
 	admins := ""
-	if len(r.users) == 0 {
-		return names
-	}
 	for _, us := range r.users {
 		if auth(us) {
 			admins += us.name + " "
@@ -61,10 +58,13 @@ func printUsersInRoom(r *room) string {
 		}
 		names += us.name + " "
 	}
-	names = names[:len(names)-1] // cut extra space at the end
+	if len(names) > 0 {
+		names = names[:len(names)-1] // cut extra space at the end
+	}
 	names = "[" + names + "]"
-
-	admins = admins[:len(admins)-1]
+	if len(names) > 0 {
+		admins = admins[:len(admins)-1]
+	}
 	admins = "[" + admins + "]"
 	return names + "  \nAdmins: " + admins
 }

--- a/util.go
+++ b/util.go
@@ -21,29 +21,23 @@ import (
 )
 
 var (
-	art                = getASCIIArt()
-	admins, adminsInfo = getAdmins()
+	art    = getASCIIArt()
+	admins = getAdmins()
 )
 
-func getAdmins() ([]string, []string) {
+func getAdmins() map[string]string {
 	data, err := ioutil.ReadFile("admins.json")
 	if err != nil {
 		fmt.Println("Error reading admins.json:", err, ". Make an admins.json file to add admins.")
-		return []string{}, []string{}
+		return nil
 	}
 	var adminsList map[string]string // id to info
 	err = json.Unmarshal(data, &adminsList)
 	if err != nil {
-		fmt.Println("Error in formating.")
-		return []string{}, []string{}
+		fmt.Println("Error in admins.json formatting.")
+		return nil
 	}
-	ids := make([]string, 0, len(adminsList))
-	infos := make([]string, 0, len(adminsList))
-	for id, info := range adminsList {
-		ids = append(ids, id)
-		infos = append(infos, info)
-	}
-	return ids, infos
+	return adminsList
 }
 
 func getASCIIArt() string {
@@ -56,18 +50,23 @@ func getASCIIArt() string {
 
 func printUsersInRoom(r *room) string {
 	names := ""
+	admins := ""
 	if len(r.users) == 0 {
 		return names
 	}
 	for _, us := range r.users {
 		if auth(us) {
-			names += "⭐"
+			admins += us.name + " "
+			continue
 		}
 		names += us.name + " "
 	}
 	names = names[:len(names)-1] // cut extra space at the end
 	names = "[" + names + "]"
-	return names
+
+	admins = admins[:len(admins)-1]
+	admins = "[" + admins + "]"
+	return names + "  \nAdmins: " + admins
 }
 
 func lenString(a string) int {
@@ -86,12 +85,8 @@ func autogenCommands(cmds []cmd) string {
 
 // check if a user is an admin
 func auth(u *user) bool {
-	for _, id := range admins {
-		if u.id == id {
-			return true
-		}
-	}
-	return false
+	_, ok := admins[u.id]
+	return ok
 }
 
 func cleanName(name string) string {


### PR DESCRIPTION
This add some of the fixes suggested in #89.
A `admins` command list all admins.
When listing users in room, admins have a star before their names.