### PR TITLE
Enable the use of @<name> in commands.

### DIFF
--- a/main.go
+++ b/main.go
@@ -569,7 +569,7 @@ func (u *User) pickUsernameQuietly(possibleName string) error {
 	var err error
 	for {
 		if possibleName == "" {
-		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" {
+		} else if strings.HasPrefix(possibleName, "#") || possibleName == "devbot" || strings.HasPrefix(possibleName, "@") {
 			u.writeln("", "Your username is invalid. Pick a different one:")
 		} else if otherUser, dup := userDuplicate(u.room, possibleName); dup {
 			if otherUser == u {

--- a/util.go
+++ b/util.go
@@ -191,7 +191,7 @@ func findUserByName(r *Room, name string) (*User, bool) {
 	r.usersMutex.Lock()
 	defer r.usersMutex.Unlock()
 	for _, u := range r.users {
-		if stripansi.Strip(u.Name) == name {
+		if stripansi.Strip(u.Name) == name || "@" + stripansi.Strip(u.Name) == name {
 			return u, true
 		}
 	}


### PR DESCRIPTION
This let us use the autocomplete in commands such as bio, pronouns, or DMs.
Names can no longer start with '@' to ensure no ambiguity.