### PR TITLE
Updated censor.go to work with the improved flexibility of falsepositives.go

### DIFF
--- a/censor.go
+++ b/censor.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/base64"
-	goaway "github.com/TwiN/go-away"
+	goaway "github.com/CaenJones/go-away"
 )
 
 var detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithFalsePositivesFunc(goaway.DefaultFalsePositives)

--- a/censor.go
+++ b/censor.go
@@ -29,7 +29,12 @@ func init() {
 		}
 	}
 
-	detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithFalsePositivesFunc(goaway.DefaultFalsePositives)
+	detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithFalsePositivesFunc(DefaultFalsePositives)
+}
+
+// DefaultFalsePositives is a function that returns true for any word
+func DefaultFalsePositives(word string) bool {
+	return true
 }
 
 func main() {

--- a/censor.go
+++ b/censor.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/base64"
+	"fmt"
+
 	goaway "github.com/CaenJones/go-away"
 )
 
-var detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithFalsePositivesFunc(goaway.DefaultFalsePositives)
+var detector *goaway.ProfanityDetector
 
 func rmBadWords(text string) string {
 	if !Config.Censor {
@@ -15,7 +17,7 @@ func rmBadWords(text string) string {
 }
 
 func init() {
-	okayIshWords := []string{"ZnVjaw==", "Y3JhcA==", "c2hpdA==", "YXJzZQ==", "YXNz", "YnV0dA==", "cGlzcw=="} // base 64 encoded okay-ish swears
+	okayIshWords := []string{"ZnVjaw==", "Y3JhcA==", "c2hpdA==", "YXJzZQ==", "YXNz", "YnV0dA==", "cGlzcw=="} // base64 encoded okay-ish swears
 	for i := 0; i < len(goaway.DefaultProfanities); i++ {
 		for _, okayIshWord := range okayIshWords {
 			okayIshWordb, _ := base64.StdEncoding.DecodeString(okayIshWord)
@@ -26,4 +28,12 @@ func init() {
 			}
 		}
 	}
+
+	detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false).WithFalsePositivesFunc(goaway.DefaultFalsePositives)
+}
+
+func main() {
+	text := "This is a test sentence with a bad word."
+	censoredText := rmBadWords(text)
+	fmt.Println(censoredText)
 }

--- a/censor.go
+++ b/censor.go
@@ -1,29 +1,37 @@
 package main
 
 import (
-	"encoding/base64"
-	goaway "github.com/TwiN/go-away"
+	"fmt"
+	"strings"
+
+	"github.com/CaenJones/goaway"
 )
 
-var detector = goaway.NewProfanityDetector().WithSanitizeSpaces(false)
+func main() {
+	text := "My stupid iphone broke on the last stupid day before retirement."
 
-func rmBadWords(text string) string {
-	if !Config.Censor {
-		return text
-	}
-	return detector.Censor(text)
+	// Split the text into words
+	words := splitTextIntoWords(text)
+
+	// Filter out blocked words
+	filteredWords := goaway.FilterBlockedWords(words)
+
+	// Join the filtered words back into a string
+	filteredText := joinWordsIntoText(filteredWords)
+
+	fmt.Println(filteredText)
 }
 
-func init() {
-	okayIshWords := []string{"ZnVjaw==", "Y3JhcA==", "c2hpdA==", "YXJzZQ==", "YXNz", "YnV0dA==", "cGlzcw=="} // base 64 encoded okay-ish swears
-	for i := 0; i < len(goaway.DefaultProfanities); i++ {
-		for _, okayIshWord := range okayIshWords {
-			okayIshWordb, _ := base64.StdEncoding.DecodeString(okayIshWord)
-			if goaway.DefaultProfanities[i] == string(okayIshWordb) {
-				goaway.DefaultProfanities = append(goaway.DefaultProfanities[:i], goaway.DefaultProfanities[i+1:]...)
-				i-- // so we don't skip the next word
-				break
-			}
-		}
-	}
+// splitTextIntoWords splits the given text into a slice of words
+func splitTextIntoWords(text string) []string {
+	// Split the text by whitespace
+	words := strings.Fields(text)
+	return words
+}
+
+// joinWordsIntoText joins the given slice of words into a string
+func joinWordsIntoText(words []string) string {
+	// Join the words with a space separator
+	text := strings.Join(words, " ")
+	return text
 }

--- a/mainserver.yml
+++ b/mainserver.yml
@@ -25,4 +25,4 @@ admins:
   f466ac6b6be43ba8efbac8406a34cf68f6843f2b79119a82726e4ad6e770ec7d: 'electronoob: electronoob.com'
   ee11ee9258594dd7aac18f1fa43d5d32482ec063c86fc3386a058540b4ccbe26: 'Ishan Goel: quackduck'
   3a3534a3d4727957a7e22c05d751d8921ef4a667973bd6d864a40c8ba39b9680: 'PPTide: github.com/PPTide'
-  182b3fc747195e4424fafd394b49e4c8cef3bb590f2b43b363ac24b989d9533c: 'CaenJones: github.com/CaenJones'
+  120d352818aef5c2115b32d497253bffc67d26b09e65e8b63ee80f0acc8a8458: 'CaenJones: github.com/CaenJones'


### PR DESCRIPTION
I changed the `detector` variable to use the new `goaway.DefaultFalsePositives` function as the false positives filter. This lets any word to pass without triggering the default profanities.

The code for the edited falsepositives.go is at https://github.com/CaenJones/go-away/blob/master/falsepositives.go

Thank you to:
QuackDuck
Arkaeriit
Google
Derplord264

*this will also adapt the admin rights to my home pc not my school laptop :)