### PR TITLE
Fix lstokens command

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"os"
 	"regexp"

--- a/rpc.go
+++ b/rpc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"regexp"
@@ -374,9 +375,11 @@ func lsTokensCMD(_ string, u *User) {
 	}
 	msg := "Tokens:  \n"
 	i := 0
+	tokenNumberSize := int(math.Log10(float64(len(Tokens)))) + 1
+	tokenNumberFormatFlag := "%0" + strconv.Itoa(tokenNumberSize) + "d"
 	for t := range Tokens {
+		msg += Cyan.Cyan(fmt.Sprintf(tokenNumberFormatFlag, i+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
 		i++
-		msg += Cyan.Cyan(strconv.Itoa(i+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
 	}
 	u.writeln(Devbot, msg)
 }

--- a/rpc.go
+++ b/rpc.go
@@ -375,8 +375,7 @@ func lsTokensCMD(_ string, u *User) {
 	}
 	msg := "Tokens:  \n"
 	i := 0
-	tokenNumberSize := int(math.Log10(float64(len(Tokens)))) + 1
-	tokenNumberFormatFlag := "%0" + strconv.Itoa(tokenNumberSize) + "d"
+	tokenNumberFormatFlag := "%0" + fmt.Sprint(len(fmt.Sprint(len(Tokens)))) + "d"
 	for t := range Tokens {
 		msg += Cyan.Cyan(fmt.Sprintf(tokenNumberFormatFlag, i+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
 		i++

--- a/rpc.go
+++ b/rpc.go
@@ -373,8 +373,10 @@ func lsTokensCMD(_ string, u *User) {
 	}
 	msg := "Tokens:  \n"
 	fmtString := "%" + fmt.Sprint(len(fmt.Sprint(len(Tokens)))) + "d"
+	i := 1
 	for t := range Tokens {
-		msg += Cyan.Cyan(fmt.Sprintf(fmtString, t+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
+		msg += Cyan.Cyan(fmt.Sprintf(fmtString, i)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
+		i++
 	}
 	u.writeln(Devbot, msg)
 }

--- a/rpc.go
+++ b/rpc.go
@@ -372,11 +372,9 @@ func lsTokensCMD(_ string, u *User) {
 		return
 	}
 	msg := "Tokens:  \n"
-	i := 0
 	tokenNumberFormatFlag := "%0" + fmt.Sprint(len(fmt.Sprint(len(Tokens)))) + "d"
 	for t := range Tokens {
-		msg += Cyan.Cyan(fmt.Sprintf(tokenNumberFormatFlag, i+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
-		i++
+		msg += Cyan.Cyan(fmt.Sprintf(tokenNumberFormatFlag, t+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
 	}
 	u.writeln(Devbot, msg)
 }

--- a/rpc.go
+++ b/rpc.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"

--- a/rpc.go
+++ b/rpc.go
@@ -372,9 +372,9 @@ func lsTokensCMD(_ string, u *User) {
 		return
 	}
 	msg := "Tokens:  \n"
-	tokenNumberFormatFlag := "%0" + fmt.Sprint(len(fmt.Sprint(len(Tokens)))) + "d"
+	fmtString := "%" + fmt.Sprint(len(fmt.Sprint(len(Tokens)))) + "d"
 	for t := range Tokens {
-		msg += Cyan.Cyan(fmt.Sprintf(tokenNumberFormatFlag, t+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
+		msg += Cyan.Cyan(fmt.Sprintf(fmtString, t+1)) + ". " + shasum(t) + "\t" + Tokens[t] + "  \n"
 	}
 	u.writeln(Devbot, msg)
 }


### PR DESCRIPTION
There is two issues with the current implementation of `lstoken`.
* The first token is numbered '2'.
* The numbers are not 0 padded which cause the column to be misaligned which hurts the Feng Shui of the output.

![miss_lstoken](https://github.com/quackduck/devzat/assets/47985708/599ce1b6-694f-4f86-b624-dd7acac877f2)

This PR fixes those two issues.

![good_lstoken](https://github.com/quackduck/devzat/assets/47985708/3e964faa-2b70-4e80-bff1-1882110325a6)

