### PR TITLE
Move the invocation of middleware

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -115,6 +115,7 @@ func runCommands(line string, u *User) {
 	}
 
 	// Now we know it is not a DM, so this is a safe place to add the hook for sending the event to plugins
+	line = getMiddlewareResult(u, line)
 	sendMessageToPlugins(line, u)
 
 	switch currCmd {

--- a/main.go
+++ b/main.go
@@ -808,8 +808,6 @@ func (u *User) repl() {
 			return
 		}
 
-		line = getMiddlewareResult(u, line)
-
 		line += "\n"
 		hasNewlines := false
 		//oldPrompt := u.Name + ": "


### PR DESCRIPTION
The current use of middleware had two issue:
* As the message was processed before we check if the message is a DM, middleware admin could snoop on any DM. This is not great for privacy.
* Bridge messages didn't go though middleware. On a first thought, this might have been seen as a good thing considering this reduce the difference between what is on the bridge and what is on the SSH interface. But there is already a lot of difference between messages sent on bridges and how the appear on the SSH interface. Messages can be edited on bridges, custom emotes are used there, and go-away censor the messages from bridges.