### PR TITLE
Fix an assignment to err

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 			}
 		}()
 	}
-	err := ssh.ListenAndServe(fmt.Sprintf(":%d", Config.Port), nil, ssh.HostKeyFile(Config.KeyFile),
+	err = ssh.ListenAndServe(fmt.Sprintf(":%d", Config.Port), nil, ssh.HostKeyFile(Config.KeyFile),
 		ssh.PublicKeyAuth(func(ctx ssh.Context, key ssh.PublicKey) bool {
 			return true // allow all keys, this lets us hash pubkeys later
 		}),


### PR DESCRIPTION
Use of `err := <...>` while err is already defined prevents compilation on go 1.19.