### PR TITLE
Make installation instructions more easy to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ go install # or build, if you want to keep things pwd
 ssh-keygen -qN '' -f devzat-sshkey # new ssh host key for the server
 devzat # run! the default config is used & written automatically
 ```
-These commands download, build, setup and run a Devzat server listening on port 2221, the default port (change by setting `$PORT`).
+These commands download, build, setup and run a Devzat server listening on port 2221, the default port (change by setting `$PORT`). Devzat is installed into `$GOPATH`, make sure `$GOPATH` is [added to your PATH](https://go.dev/wiki/SettingGOPATH) 
 
 Check out the [Admin's Manual](Admin's%20Manual.md) for complete self-host documentation!
 


### PR DESCRIPTION
Explain that users often need to add GOPATH to their PATH for `go install` works.

Alternatively we could use `go build` in the selfhosting instructions?