### PR TITLE
Fix Backlog messages always Default Messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -528,7 +528,7 @@ func newUser(s ssh.Session) *User {
 				lastStamp = Backlog[i].timestamp
 				u.rWriteln(fmtTime(u, lastStamp))
 			}
-			u.writeln(NewMessage(Backlog[i].senderName, Backlog[i].text))
+			u.writeln(Backlog[i].Message)
 		}
 		if time.Since(lastStamp) > time.Minute && u.Timezone.Location != nil {
 			u.rWriteln(fmtTime(u, time.Now()))


### PR DESCRIPTION
Backlog messages should be writen back with the same Message type as what they originally where. Atm join Messages in the Backlog are prefixed with ": "