### PR TITLE
Specify golangci-lint version.

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18.0"
+          go-version: "1.22"
           check-latest: true
       - uses: actions/checkout@v3
       - name: golangci-lint


### PR DESCRIPTION
The latest version doesn't work on the container
used to run it.