### PR TITLE
Plugins can send commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -105,7 +105,7 @@ func runCommands(line string, u *User) {
 	line = rmBadWords(line)
 
 	if u.IsMuted {
-		u.writeln(NewMessage(u.Name, line))
+		u.writeln(NewMessage(u, line))
 		return
 	}
 
@@ -143,9 +143,9 @@ func runCommands(line string, u *User) {
 	}
 
 	if u.isBridge {
-		u.room.broadcastNoBridges(NewMessage(u.Name, line))
+		u.room.broadcastNoBridges(NewMessage(u, line))
 	} else {
-		u.room.broadcast(NewMessage(u.Name, line))
+		u.room.broadcast(NewMessage(u, line))
 	}
 
 	devbotChat(u.room, line)
@@ -175,7 +175,7 @@ func dmCMD(rest string, u *User) {
 		return
 	}
 	msg := strings.TrimSpace(strings.TrimPrefix(rest, restSplit[0]))
-	u.writeln(NewPrivateMessage(peer.Name, msg, true))
+	u.writeln(NewPrivateMessage(peer, msg, true))
 	if u == peer {
 		devbotRespond(u.room, []string{"You must be really lonely, DMing yourself.",
 			"Don't worry, I won't judge :wink:",
@@ -183,13 +183,13 @@ func dmCMD(rest string, u *User) {
 			"what an idiot"}, 30)
 		return
 	}
-	peer.writeln(NewPrivateMessage(u.Name, msg, false))
+	peer.writeln(NewPrivateMessage(u, msg, false))
 }
 
 func hangCMD(rest string, u *User) {
 	if len([]rune(rest)) > 1 {
 		if !u.isBridge {
-			u.writeln(NewMessage(u.Name, "hang "+rest))
+			u.writeln(NewMessage(u, "hang "+rest))
 			u.writeln(NewDevbotMessage("(that word won't show dw)"))
 		}
 		hangGame = &hangman{rest, 15, " "} // default value of guesses so empty space is given away
@@ -198,7 +198,7 @@ func hangCMD(rest string, u *User) {
 		return
 	}
 	if !u.isBridge {
-		u.room.broadcast(NewMessage(u.Name, "hang "+rest))
+		u.room.broadcast(NewMessage(u, "hang "+rest))
 	}
 	if strings.Trim(hangGame.word, hangGame.guesses) == "" {
 		u.room.broadcast(NewDevbotMessage("The game has ended. Start a new game with hang <word>"))
@@ -248,7 +248,7 @@ func usersCMD(_ string, u *User) {
 }
 
 func dmRoomCMD(line string, u *User) {
-	u.writeln(NewPrivateMessage(u.messaging.Name, line, true))
+	u.writeln(NewPrivateMessage(u.messaging, line, true))
 	if u == u.messaging {
 		devbotRespond(u.room, []string{"You must be really lonely, DMing yourself.",
 			"Don't worry, I won't judge :wink:",
@@ -256,7 +256,7 @@ func dmRoomCMD(line string, u *User) {
 			"what an idiot"}, 30)
 		return
 	}
-	u.messaging.writeln(NewPrivateMessage(u.Name, line, false))
+	u.messaging.writeln(NewPrivateMessage(u, line, false))
 }
 
 // named devmonk at the request of a certain ced
@@ -382,14 +382,14 @@ func cdCMD(rest string, u *User) {
 		}
 	}
 	if rest == ".." { // cd back into the main room
-		u.room.broadcast(NewMessage(u.Name, "cd "+rest))
+		u.room.broadcast(NewMessage(u, "cd "+rest))
 		if u.room != MainRoom {
 			u.changeRoom(MainRoom)
 		}
 		return
 	}
 	if strings.HasPrefix(rest, "#") {
-		u.room.broadcast(NewMessage(u.Name, "cd "+rest))
+		u.room.broadcast(NewMessage(u, "cd "+rest))
 		if len(rest) > MaxRoomNameLen {
 			rest = rest[0:MaxRoomNameLen]
 			u.room.broadcast(NewDevbotMessage("Room name lengths are limited, so I'm shortening it to " + rest + "."))
@@ -403,7 +403,7 @@ func cdCMD(rest string, u *User) {
 		return
 	}
 	if rest == "" {
-		u.room.broadcast(NewMessage(u.Name, "cd "+rest))
+		u.room.broadcast(NewMessage(u, "cd "+rest))
 		type kv struct {
 			roomName   string
 			numOfUsers int
@@ -756,7 +756,7 @@ func pwdCMD(_ string, u *User) {
 }
 
 func shrugCMD(line string, u *User) {
-	u.room.broadcast(NewMessage(u.Name, line+` ¯\\_(ツ)_/¯`))
+	u.room.broadcast(NewMessage(u, line+` ¯\\_(ツ)_/¯`))
 }
 
 func pronounsCMD(line string, u *User) {
@@ -949,7 +949,7 @@ func eightBallCMD(_ string, u *User) {
 	}
 	go func() {
 		time.Sleep(time.Second * time.Duration(rand.Intn(10)))
-		u.room.broadcast(NewMessage("8ball", responses[rand.Intn(len(responses))]+u.Name))
+		u.room.broadcast(NewFakeUserMessage("8ball", responses[rand.Intn(len(responses))]+u.Name, u.room))
 	}()
 }
 

--- a/devzat_test.go
+++ b/devzat_test.go
@@ -4,62 +4,26 @@
 package main
 
 import (
-	"io"
-	"net"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/acarl005/stripansi"
-	"github.com/gliderlabs/ssh"
-	terminal "github.com/quackduck/term"
 )
 
-type dummyRW struct{}
-
-func (rw dummyRW) Read(p []byte) (n int, err error)  { return 0, nil }
-func (rw dummyRW) Write(p []byte) (n int, err error) { return 0, nil }
-
-type dummySession struct{}
-
-func (s dummySession) User() string                            { return "" }
-func (s dummySession) RemoteAddr() net.Addr                    { return nil }
-func (s dummySession) LocalAddr() net.Addr                     { return nil }
-func (s dummySession) Environ() []string                       { return make([]string, 0) }
-func (s dummySession) Exit(code int) error                     { return nil }
-func (s dummySession) Command() []string                       { return make([]string, 0) }
-func (s dummySession) RawCommand() string                      { return "" }
-func (s dummySession) Subsystem() string                       { return "" }
-func (s dummySession) PublicKey() ssh.PublicKey                { return nil }
-func (s dummySession) Context() ssh.Context                    { return nil }
-func (s dummySession) Permissions() ssh.Permissions            { return ssh.Permissions{} }
-func (s dummySession) Pty() (ssh.Pty, <-chan ssh.Window, bool) { return ssh.Pty{}, nil, true }
-func (s dummySession) Signals(c chan<- ssh.Signal)             {}
-func (s dummySession) Break(c chan<- bool)                     {}
-func (s dummySession) Close() error                            { return nil }
-func (s dummySession) CloseWrite() error                       { return nil }
-func (s dummySession) Read(data []byte) (int, error)           { return 0, nil }
-func (s dummySession) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
-	return false, nil
-}
-func (s dummySession) Stderr() io.ReadWriter          { return nil }
-func (s dummySession) Write(data []byte) (int, error) { return 0, nil }
-
 func makeDummyRoom() *Room {
-	drw := dummyRW{}
-	dummyTerm := terminal.NewTerminal(drw, "")
 	ret := &Room{name: "DummyRoom", users: []*User{}, usersMutex: sync.RWMutex{}}
 
-	tim := &User{Name: "tim", term: dummyTerm, ColorBG: "bg-off", room: ret, session: dummySession{}}
+	tim := makeDummyUser("tim", ret)
 	_ = tim.changeColor("green")
-	tom := &User{Name: "tom", term: dummyTerm, ColorBG: "bg-off", room: ret, session: dummySession{}}
+	tom := makeDummyUser("tom", ret)
 	_ = tom.changeColor("blue")
-	timtom := &User{Name: "timtom", term: dummyTerm, ColorBG: "bg-off", room: ret, session: dummySession{}}
+	timtom := makeDummyUser("timtom", ret)
 	_ = timtom.changeColor("sky")
-	timt := &User{Name: "timt", term: dummyTerm, ColorBG: "bg-off", room: ret, session: dummySession{}}
+	timt := makeDummyUser("timt", ret)
 	_ = timt.changeColor("coral")
 
-	ret.users = append(ret.users, tim, tom, timtom, timt)
+	ret.users = append(ret.users, &tim, &tom, &timtom, &timt)
 	return ret
 }
 

--- a/discord.go
+++ b/discord.go
@@ -154,7 +154,7 @@ func discordMessageHandler(_ *discordgo.Session, m *discordgo.MessageCreate) {
 			Log.Println("Overflow in Slack channel")
 		}
 	}
-	runCommands(msgContent, DiscordUser)
+	runCommands(NewMessage(DiscordUser, msgContent))
 }
 
 var cacheSize = 20

--- a/main.go
+++ b/main.go
@@ -225,9 +225,9 @@ func (r *Room) broadcast(msg Message) {
 
 	if Integrations.Slack != nil || Integrations.Discord != nil {
 		var toSendS string
-		if msg.senderName != "" {
+		if msg.getMessageSenderName() != "" {
 			if Integrations.Slack != nil {
-				toSendS = "[" + r.name + "] *" + msg.senderName + "*: " + msg.text
+				toSendS = "[" + r.name + "] *" + msg.getMessageSenderName() + "*: " + msg.text
 			}
 		} else {
 			toSendS = "[" + r.name + "] " + msg.text
@@ -242,7 +242,7 @@ func (r *Room) broadcast(msg Message) {
 		if Integrations.Discord != nil {
 			select {
 			case DiscordChan <- DiscordMsg{
-				senderName: msg.senderName,
+				senderName: msg.getMessageSenderName(),
 				msg:        msg.text,
 				channel:    r.name,
 			}:
@@ -646,37 +646,57 @@ func (u *User) ban(banMsg string, useTime bool, unbanTime time.Time) {
 }
 
 type Message struct {
-	senderName string
-	text       string
+	sender *User
+	text   string
 
 	messageType      MessageType
 	sentFromPluginId string
 }
 
-func NewMessage(senderName, text string) Message {
-	return Message{senderName, text, DefaultMessage, ""}
+func NewMessage(sender *User, text string) Message {
+	return Message{sender, text, DefaultMessage, ""}
+}
+
+func NewFakeUserMessage(sender string, text string, room *Room) Message {
+	senderUser := makeDummyUser(sender, room)
+	return NewMessage(&senderUser, text)
+}
+
+func NewFakeUserPrivateMessage(sender string, text string) Message {
+	senderUser := User{Name: sender}
+	return NewPrivateMessage(&senderUser, text, false)
 }
 
 func NewDevbotMessage(text string) Message {
-	return Message{Devbot, text, DefaultMessage, ""}
+	return NewFakeUserMessage(Devbot, text, MainRoom) // As devbot messages are either directly broadcasted to a room or unicasted to an user, the room argument is kinda irrelevant
 }
 
 func NewNoSenderMessage(text string) Message {
-	return Message{"", text, NoSenderMessage, ""}
+	return Message{nil, text, NoSenderMessage, ""}
 }
 
-func NewPrivateMessage(senderName, text string, isSender bool) Message {
+func NewPrivateMessage(sender *User, text string, isSender bool) Message {
 	messageType := PrivateMessageReceive
 	if isSender {
 		messageType = PrivateMessageSend
 	}
-	return Message{senderName, text, messageType, ""}
+	return Message{sender, text, messageType, ""}
 }
 
 func (msg Message) dontSendToPlugin(pluginId string) Message {
 	msg.sentFromPluginId = pluginId
 	return msg
 }
+
+func (msg Message) getMessageSenderName() string {
+	if msg.sender == nil {
+		return ""
+	} else {
+		return msg.sender.Name
+	}
+}
+
+
 
 type MessageType int
 
@@ -698,15 +718,15 @@ func (u *User) writelnWithImageCache(msg Message, cache map[string]image.Image) 
 	thisUserIsDMSender := msg.messageType == PrivateMessageSend
 	switch msg.messageType {
 	case PrivateMessageSend:
-		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.senderName), u.winWidth, cache))
-		msg.text = msg.senderName + " <- " + msg.text
+		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.getMessageSenderName()), u.winWidth, cache))
+		msg.text = msg.getMessageSenderName() + " <- " + msg.text
 	case PrivateMessageReceive:
-		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.senderName), u.winWidth, cache))
-		msg.text = msg.senderName + " -> " + msg.text
+		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.getMessageSenderName()), u.winWidth, cache))
+		msg.text = msg.getMessageSenderName() + " -> " + msg.text
 		msg.text += "\a"
 	case DefaultMessage:
-		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.senderName)+2, u.winWidth, cache))
-		msg.text = msg.senderName + ": " + msg.text
+		msg.text = strings.TrimSpace(mdRender(msg.text, lenString(msg.getMessageSenderName())+2, u.winWidth, cache))
+		msg.text = msg.getMessageSenderName() + ": " + msg.text
 	case NoSenderMessage:
 		msg.text = strings.TrimSpace(mdRender(msg.text, 0, u.winWidth, cache)) // No sender
 	}
@@ -714,7 +734,7 @@ func (u *User) writelnWithImageCache(msg Message, cache map[string]image.Image) 
 		u.lastTimestamp = time.Now()
 		u.rWriteln(fmtTime(u, u.lastTimestamp))
 	}
-	if u.PingEverytime && msg.senderName != u.Name && !thisUserIsDMSender {
+	if u.PingEverytime && msg.getMessageSenderName() != u.Name && !thisUserIsDMSender {
 		msg.text += "\a"
 	}
 	if !u.Bell {

--- a/main.go
+++ b/main.go
@@ -986,7 +986,7 @@ func (u *User) repl() {
 			u.close(Red.Paint(u.Name + " has been banned for spamming"))
 			return
 		}
-		runCommands(line, u)
+		runCommands(NewMessage(u, line))
 	}
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -213,7 +213,7 @@ func (s *pluginServer) SendMessage(ctx context.Context, msg *pb.Message) (*pb.Me
 		if msg.GetFrom() == "" {
 			localMsg = NewNoSenderMessage(msg.Msg)
 		} else {
-			localMsg = NewPrivateMessage(msg.GetFrom(), msg.Msg, false)
+			localMsg = NewFakeUserPrivateMessage(msg.GetFrom(), msg.Msg)
 		}
 		localMsg = localMsg.dontSendToPlugin(token)
 		u.writeln(localMsg)
@@ -227,7 +227,7 @@ func (s *pluginServer) SendMessage(ctx context.Context, msg *pb.Message) (*pb.Me
 		if msg.GetFrom() == "" {
 			localMsg = NewNoSenderMessage(msg.Msg)
 		} else {
-			localMsg = NewMessage(msg.GetFrom(), msg.Msg)
+			localMsg = NewFakeUserMessage(msg.GetFrom(), msg.Msg, r)
 		}
 		localMsg = localMsg.dontSendToPlugin(token)
 		r.broadcast(localMsg)
@@ -324,7 +324,7 @@ func sendMessageToPlugins(msg PluginMessage, excludePluginToken string) {
 			}
 			l.channel <- &pb.Event{
 				Room: msg.room,
-				From: msg.senderName,
+				From: msg.Message.getMessageSenderName(),
 				Msg:  msg.text,
 			}
 		}
@@ -347,7 +347,7 @@ func getMiddlewareResult(msg PluginMessage, excludePluginToken string) string {
 		}
 		ListenersMiddleware[i].channel <- &pb.Event{
 			Room: msg.room,
-			From: msg.senderName,
+			From: msg.Message.getMessageSenderName(),
 			Msg:  msg.text,
 		}
 		if res := (<-ListenersMiddleware[i].channel).(*pb.ListenerClientData_Response).Response.Msg; res != nil {

--- a/rpc.go
+++ b/rpc.go
@@ -226,11 +226,13 @@ func (s *pluginServer) SendMessage(ctx context.Context, msg *pb.Message) (*pb.Me
 		var localMsg Message
 		if msg.GetFrom() == "" {
 			localMsg = NewNoSenderMessage(msg.Msg)
+			localMsg = localMsg.dontSendToPlugin(token)
+			r.broadcast(localMsg)
 		} else {
 			localMsg = NewFakeUserMessage(msg.GetFrom(), msg.Msg, r)
+			localMsg = localMsg.dontSendToPlugin(token)
+			runCommands(localMsg)
 		}
-		localMsg = localMsg.dontSendToPlugin(token)
-		r.broadcast(localMsg)
 	}
 	return &pb.MessageRes{}, nil
 }

--- a/slack.go
+++ b/slack.go
@@ -58,7 +58,7 @@ func getMsgsFromSlack() {
 					Log.Println("Overflow in Discord channel")
 				}
 			}
-			runCommands(text, uslack)
+			runCommands(NewMessage(uslack, text))
 		case *slack.ConnectedEvent:
 			SlackBotID = ev.Info.User.ID
 			Log.Println("Connected to Slack with bot ID", SlackBotID, "as", ev.Info.User.Name)


### PR DESCRIPTION
This PR refactor how messages and commands are handled to let plugins execute Devzat commands. This has been tested with the courier plugin on another Devzat instance.