### PR TITLE
[WIP] Prototype of a username/password authentication system

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -72,6 +72,10 @@ var (
 		{"8ball", eightBallCMD, "`question`", "Always tells the truth."},
 		{"rmdir", rmdirCMD, "#`room`", "Remove an empty room"},
 		{"logs", logsCMD, "[`lines`]", "Show server logs (admin)"},
+		{"adduser", addUserCMD, "`username` `password`", "Register a user with a password (admin)"},
+		{"removeuser", removeUserCMD, "`username`", "Remove a user registration (admin)"},
+		{"listusers", listUsersCMD, "", "List registered users (admin)"},
+		{"passwd", passwdCMD, "", "Change your own password"},
 	}
 	SecretCMDs = []CMD{
 		{"ls", lsCMD, "???", "???"},
@@ -140,6 +144,15 @@ func runCommands(msg Message) {
 		if clear_if_rest_empty(strings.TrimSpace(strings.TrimPrefix(msg.text, "clear")), msg.sender) {
 			return
 		}
+	case "adduser":
+		addUserCMD(strings.TrimSpace(strings.TrimPrefix(msg.text, "adduser")), msg.sender)
+		return
+	case "removeuser":
+		removeUserCMD(strings.TrimSpace(strings.TrimPrefix(msg.text, "removeuser")), msg.sender)
+		return
+	case "passwd":
+		passwdCMD(strings.TrimSpace(strings.TrimPrefix(msg.text, "passwd")), msg.sender)
+		return
 	}
 
 	if msg.sender.isBridge {
@@ -990,4 +1003,99 @@ func logsCMD(rest string, u *User) {
 		u.writeln(NewDevbotMessage(line))
 	}
 
+}
+
+func addUserCMD(line string, u *User) {
+	if !auth(u) {
+		u.room.broadcast(NewDevbotMessage("Not authorized"))
+		return
+	}
+	parts := strings.SplitN(strings.TrimSpace(line), " ", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		u.room.broadcast(NewDevbotMessage("Usage: adduser `username` `password`"))
+		return
+	}
+	username, password := parts[0], parts[1]
+	if err := registerUser(username, password); err != nil {
+		u.room.broadcast(NewDevbotMessage("Failed to register user: " + err.Error()))
+		return
+	}
+	u.room.broadcast(NewDevbotMessage("Registered user **" + cleanName(username) + "**"))
+}
+
+func removeUserCMD(line string, u *User) {
+	if !auth(u) {
+		u.room.broadcast(NewDevbotMessage("Not authorized"))
+		return
+	}
+	username := strings.TrimSpace(line)
+	if username == "" {
+		u.room.broadcast(NewDevbotMessage("Usage: removeuser `username`"))
+		return
+	}
+	if removeRegisteredUser(username) {
+		u.room.broadcast(NewDevbotMessage("Removed user **" + cleanName(username) + "**"))
+	} else {
+		u.room.broadcast(NewDevbotMessage("User **" + cleanName(username) + "** not found"))
+	}
+}
+
+func listUsersCMD(_ string, u *User) {
+	if !auth(u) {
+		u.room.broadcast(NewDevbotMessage("Not authorized"))
+		return
+	}
+	userAuthMu.RLock()
+	names := make([]string, 0, len(UserAuthStore))
+	for name := range UserAuthStore {
+		names = append(names, name)
+	}
+	userAuthMu.RUnlock()
+	if len(names) == 0 {
+		u.room.broadcast(NewDevbotMessage("No registered users"))
+		return
+	}
+	sort.Strings(names)
+	msg := "Registered users:  \n"
+	for i, name := range names {
+		msg += Cyan.Cyan(strconv.Itoa(i+1)) + ". " + name + "  \n"
+	}
+	u.room.broadcast(NewDevbotMessage(msg))
+}
+
+func passwdCMD(_ string, u *User) {
+	if u.authName == "" {
+		u.room.broadcast(NewDevbotMessage("You are not logged in with a registered username"))
+		return
+	}
+	u.writeln(NewNoSenderMessage("Changing password for **" + u.authName + "**"))
+	oldPass, err := u.term.ReadPassword("Current password: ")
+	if err != nil {
+		return
+	}
+	if !verifyPassword(u.authName, oldPass) {
+		u.room.broadcast(NewDevbotMessage("Incorrect current password"))
+		return
+	}
+	newPass, err := u.term.ReadPassword("New password: ")
+	if err != nil {
+		return
+	}
+	if newPass == "" {
+		u.room.broadcast(NewDevbotMessage("Password cannot be empty"))
+		return
+	}
+	confirm, err := u.term.ReadPassword("Confirm new password: ")
+	if err != nil {
+		return
+	}
+	if newPass != confirm {
+		u.room.broadcast(NewDevbotMessage("Passwords do not match"))
+		return
+	}
+	if err = registerUser(u.authName, newPass); err != nil {
+		u.room.broadcast(NewDevbotMessage("Failed to change password: " + err.Error()))
+		return
+	}
+	u.room.broadcast(NewDevbotMessage("Password changed successfully"))
 }

--- a/config.go
+++ b/config.go
@@ -20,6 +20,8 @@ type ConfigType struct {
 	Censor      bool              `yaml:"censor,omitempty"`
 	Private     bool              `yaml:"private,omitempty"`
 	Allowlist   map[string]string `yaml:"allowlist,omitempty"`
+	RequireAuth      bool `yaml:"require_auth,omitempty"`
+	RequireAdminAuth bool `yaml:"require_admin_auth,omitempty"`
 
 	IntegrationConfig string `yaml:"integration_config"`
 }

--- a/main.go
+++ b/main.go
@@ -78,8 +78,9 @@ type User struct {
 
 	Color   string
 	ColorBG string
-	id      string
-	addr    string
+	id       string
+	addr     string
+	authName string // lowercase username authenticated at login (empty if no auth)
 
 	winWidth      int
 	lastTimestamp time.Time
@@ -130,6 +131,7 @@ func main() {
 		}
 	}()
 	readBans()
+	loadUserAuth()
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
@@ -487,7 +489,33 @@ func newUser(s ssh.Session) *User {
 	u.Prompt = "\\u:\\S"
 	timeoutChan := make(chan bool)
 	timedOut := false
+	sshUsername := cleanName(stripansi.Strip(s.User()))
 	go func() { // timeout to minimize inactive connections
+		if Config.RequireAuth && (!auth(u) || Config.RequireAdminAuth) {
+			if !isUserRegistered(sshUsername) {
+				if !timedOut {
+					u.writeln(NewDevbotMessage("This server requires authentication. The username **" + sshUsername + "** is not registered. Contact the server admin."))
+					s.Close()
+					s = nil
+				}
+				timeoutChan <- true
+				return
+			}
+			if !timedOut {
+				u.writeln(NewNoSenderMessage("Enter password for **" + sshUsername + "**:"))
+			}
+			password, pwErr := u.term.ReadPassword("Password: ")
+			if pwErr != nil || !verifyPassword(sshUsername, password) {
+				if !timedOut {
+					u.writeln(NewDevbotMessage("Incorrect password."))
+					s.Close()
+					s = nil
+				}
+				timeoutChan <- true
+				return
+			}
+			u.authName = strings.ToLower(sshUsername)
+		}
 		err := u.loadPrefs()
 		if err != nil && !timedOut {
 			Log.Println("Could not load user:", err)
@@ -777,6 +805,8 @@ func (u *User) pickUsernameQuietly(possibleName string) error {
 				break // allow selecting the same name as before the user tried to change it
 			}
 			u.writeln(NewNoSenderMessage("Your username is already in use. Pick a different one:"))
+		} else if Config.RequireAuth && isUserRegistered(possibleName) && strings.ToLower(possibleName) != u.authName {
+			u.writeln(NewNoSenderMessage("That username is registered and password-protected. Pick a different one:"))
 		} else { // valid name
 			break
 		}
@@ -821,13 +851,20 @@ func (u *User) savePrefs() error {
 	if err != nil {
 		return err
 	}
-	saveTo = filepath.Join(saveTo, u.id+".json")
+	saveTo = filepath.Join(saveTo, u.prefsKey()+".json")
 	err = os.WriteFile(saveTo, data, 0644)
 	return err
 }
 
+func (u *User) prefsKey() string {
+	if u.authName != "" {
+		return u.authName
+	}
+	return u.id
+}
+
 func (u *User) loadPrefs() error {
-	save := filepath.Join(Config.DataDir, "user-prefs", u.id+".json")
+	save := filepath.Join(Config.DataDir, "user-prefs", u.prefsKey()+".json")
 
 	data, err := os.ReadFile(save)
 	if err != nil {

--- a/userauth.go
+++ b/userauth.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+type UserRecord struct {
+	PasswordHash string `json:"password_hash"`
+}
+
+var (
+	UserAuthStore = map[string]*UserRecord{}
+	userAuthMu    sync.RWMutex
+)
+
+func userAuthPath() string {
+	return filepath.Join(Config.DataDir, "user-auth.json")
+}
+
+func loadUserAuth() {
+	data, err := os.ReadFile(userAuthPath())
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		Log.Println("Could not load user auth:", err)
+		return
+	}
+	userAuthMu.Lock()
+	defer userAuthMu.Unlock()
+	if err = json.Unmarshal(data, &UserAuthStore); err != nil {
+		Log.Println("Could not parse user auth:", err)
+	}
+}
+
+func saveUserAuth() error {
+	userAuthMu.RLock()
+	data, err := json.MarshalIndent(UserAuthStore, "", "  ")
+	userAuthMu.RUnlock()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(userAuthPath(), data, 0600)
+}
+
+func registerUser(username, password string) error {
+	username = strings.ToLower(cleanName(username))
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+	userAuthMu.Lock()
+	UserAuthStore[username] = &UserRecord{PasswordHash: string(hash)}
+	userAuthMu.Unlock()
+	return saveUserAuth()
+}
+
+func removeRegisteredUser(username string) bool {
+	username = strings.ToLower(cleanName(username))
+	userAuthMu.Lock()
+	_, ok := UserAuthStore[username]
+	if ok {
+		delete(UserAuthStore, username)
+	}
+	userAuthMu.Unlock()
+	if ok {
+		saveUserAuth() //nolint:errcheck
+	}
+	return ok
+}
+
+func isUserRegistered(username string) bool {
+	userAuthMu.RLock()
+	_, ok := UserAuthStore[strings.ToLower(username)]
+	userAuthMu.RUnlock()
+	return ok
+}
+
+func verifyPassword(username, password string) bool {
+	userAuthMu.RLock()
+	record, ok := UserAuthStore[strings.ToLower(username)]
+	userAuthMu.RUnlock()
+	if !ok {
+		return false
+	}
+	return bcrypt.CompareHashAndPassword([]byte(record.PasswordHash), []byte(password)) == nil
+}


### PR DESCRIPTION
* Adds require_auth and require_admin_auth config flags
* When require_auth is enabled, only registered users can connect and must provide a password
* Admins identified by SSH key hash bypass auth unless require_admin_auth is also set
* Passwords are bcrypt-hashed and stored in user-auth.json
* Prefs are keyed by authenticated username rather than IP-based ID
* Sensitive commands (adduser, removeuser, passwd) are intercepted before room broadcast to prevent password leakage

Full disclosure, I prototyped this using Claude. But I still think its straight forward enough to look at as inspiration for a username/password login system.